### PR TITLE
[auto] Add OSS policy reference to llm-providers CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ dist/
 .DS_Store
 coverage/
 .turbo/
+# cc-taskrunner worktree protection
+C:*
+node_modules/
+.pnpm-store/
+__pycache__/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+## OSS Policy
+
+This is a **public infrastructure package** governed by the Stackbilt OSS Infrastructure Package Update Policy.
+
+Rules:
+1. **Additive only** — never remove or rename public API without a major version bump
+2. **No product logic** — framework patterns and generic utilities only. If a competitor could reconstruct Stackbilt product architecture from this code, it doesn't belong here.
+3. **Strict semver** — patch for fixes, minor for new features, major for breaking changes
+4. **Tests travel with code** — every public export must have test coverage
+5. **Validate at boundaries** — all external API responses validated before returning to consumers
+
+Full policy: `stackbilt_llc/policies/oss-infrastructure-update-policy.md`


### PR DESCRIPTION
## Autonomous Task

**Task ID**: `82e34acd-05b5-4b32-9b6a-9d220ee23354`
**Authority**: auto_safe
**Exit code**: 0

## Task Prompt
Add the following section to the end of CLAUDE.md (create the file if it doesn't exist). Do NOT modify any other content in the file.

## OSS Policy

This is a **public infrastructure package** governed by the Stackbilt OSS Infrastructure Package Update Policy.

Rules:
1. **Additive only** — never remove or rename public API without a major version bump
2. **No product logic** — framework patterns and generic utilities only. If a competitor could reconstruct Stackbilt product architecture from this code, it doesn't belong here.
3. **Strict semver** — patch for fixes, minor for new features, major for breaking changes
4. **Tests travel with code** — every public export must have test coverage
5. **Validate at boundaries** — all external API responses validated before returning to consumers

Full policy: `stackbilt_llc/policies/oss-infrastructure-update-policy.md`

Commit with message: "docs: add OSS policy reference to CLAUDE.md"

TASK_COMPLETE

## Result Summary
Created `CLAUDE.md` with the OSS policy section. Typecheck and all 146 tests pass. Committed as `ec312bf`.

TASK_COMPLETE

---
Generated by AEGIS task runner. Review before merging.