### PR TITLE
fix: revert duplicate LLMProviders.fromEnv() — TS2393 broke build

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -373,26 +373,6 @@ export class LLMProviders {
   updateConfig(config: Partial<ProviderFactoryConfig>): void {
     this.factory.updateConfig(config);
   }
-
-  /**
-   * Create LLMProviders by auto-discovering providers from a Cloudflare Workers env object.
-   * Inspects well-known env keys: AI (CF Workers AI binding), GROQ_API_KEY, CEREBRAS_API_KEY.
-   */
-  static fromEnv(env: Record<string, unknown>): LLMProviders {
-    const config: ProviderFactoryConfig = { defaultProvider: 'auto' };
-
-    if (env['AI']) {
-      config.cloudflare = { ai: env['AI'] as Ai };
-    }
-    if (typeof env['GROQ_API_KEY'] === 'string' && env['GROQ_API_KEY']) {
-      config.groq = { apiKey: env['GROQ_API_KEY'] };
-    }
-    if (typeof env['CEREBRAS_API_KEY'] === 'string' && env['CEREBRAS_API_KEY']) {
-      config.cerebras = { apiKey: env['CEREBRAS_API_KEY'] };
-    }
-
-    return new LLMProviders(config);
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Reverts 33aaf53. That commit added a second `static fromEnv()` to the `LLMProviders` class without noticing the existing one (added 2026-04-01 in `743a1e04`, PRs #7/#8). TypeScript correctly errored:

```
src/index.ts(218,10): error TS2393: Duplicate function implementation.
src/index.ts(381,10): error TS2393: Duplicate function implementation.
```

Broke `npm run build` (`prepare` script is `tsc`), which means **publish is blocked** AND every downstream consumer that builds llm-providers from main as a sibling-checkout dep currently has red CI.

## Why revert vs. fix-forward

The reverted impl was a strict subset of the existing `fromEnv` — same pattern, fewer providers (no Anthropic, no OpenAI), no `FromEnvOverrides` support, silent on empty-env (the existing one throws `ConfigurationError`). Nothing salvageable. The existing `fromEnv` at `src/index.ts:218` already covers the use case the reverted commit's message describes:

| Feature | Existing (line 218) | Reverted (line 381) |
|---|---|---|
| Providers | Anthropic + OpenAI + Groq + Cerebras + CF AI | Groq + Cerebras + CF AI |
| Overrides | `FromEnvOverrides` (defaultProvider, costOpt, breaker, retries, fallback, ledger, quotaHook, hooks) | none |
| Empty env | throws `ConfigurationError` | silently returns empty-config instance |

## Validation

- `npm run build` — clean (`tsc` exit 0) locally on this branch
- No test changes; no API surface change (the existing `fromEnv` is unchanged)

## Test plan

- [ ] CI green on this PR
- [ ] After merge: downstream sibling-checkout consumers' typecheck jobs go green
- [ ] Confirm `npm publish` is unblocked (separate follow-up, not gated on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)