### PR TITLE
fix: remove duplicate LLMProviders.fromEnv() method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -374,25 +374,6 @@ export class LLMProviders {
     this.factory.updateConfig(config);
   }
 
-  /**
-   * Create LLMProviders by auto-discovering providers from a Cloudflare Workers env object.
-   * Inspects well-known env keys: AI (CF Workers AI binding), GROQ_API_KEY, CEREBRAS_API_KEY.
-   */
-  static fromEnv(env: Record<string, unknown>): LLMProviders {
-    const config: ProviderFactoryConfig = { defaultProvider: 'auto' };
-
-    if (env['AI']) {
-      config.cloudflare = { ai: env['AI'] as Ai };
-    }
-    if (typeof env['GROQ_API_KEY'] === 'string' && env['GROQ_API_KEY']) {
-      config.groq = { apiKey: env['GROQ_API_KEY'] };
-    }
-    if (typeof env['CEREBRAS_API_KEY'] === 'string' && env['CEREBRAS_API_KEY']) {
-      config.cerebras = { apiKey: env['CEREBRAS_API_KEY'] };
-    }
-
-    return new LLMProviders(config);
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Commit \`33aaf53\` added a new feature-complete \`fromEnv(env, overrides?)\` at class-body top but left the older 3-provider \`fromEnv(env)\` in place at class-body bottom. TypeScript 5.x catches this as \`TS2393 Duplicate function implementation\` so downstream CI builds fail at \`tsc\` on \`npm install\`.

Blocks \`Stackbilt-dev/foodfiles#116\` (Charter CI green needed to merge FoodFiles auth path fix).

## What changed

Deleted the older \`fromEnv(env)\` stub (src/index.ts:377-395). Surviving method at :218 is a strict superset:

- **5 providers** (anthropic, openai, groq, cerebras, cloudflare) vs the old 3 (cloudflare, groq, cerebras)
- \`FromEnvOverrides\` hook for \`defaultProvider\`, \`costOptimization\`, \`enableCircuitBreaker\`, \`enableRetries\`, \`fallbackRules\`, \`ledger\`, \`quotaHook\`, \`quotaFailPolicy\`, \`hooks\`
- Throws \`ConfigurationError\` on no providers detected (safer default than the old silent \`defaultProvider: 'auto'\` fallback)

Back-compatible with existing 1-arg callers (\`LLMProviders.fromEnv(env)\`) because the second param is optional.

## Test plan

- [x] \`npm run build\` clean (TS2393 resolved)
- [x] All 229 tests pass (including the 21-test \`from-env.test.ts\` suite)
- [ ] Downstream Charter CI green on foodfiles#116

🤖 Generated with [Claude Code](https://claude.com/claude-code)