### PR TITLE
ci: bump actions/checkout + actions/setup-node to v6 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         node-version: [18, 20, 22]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,8 @@ jobs:
       contents: read
       id-token: write  # Required for npm provenance
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
## Summary
- Upgrades `actions/checkout` and `actions/setup-node` from v4 → v6 in both `ci.yml` and `publish.yml`.
- v6 of both actions runs natively on Node 24, so this preempts GitHub's forced Node 20 → Node 24 swap on 2026-06-02 and Node 20's removal from runners on 2026-09-16.
- Silences the deprecation annotations that surfaced on the v1.5.0 publish run.

No functional change — matrix Node versions (18/20/22 in CI, 22 in publish) are unchanged; this only bumps the Node runtime the actions themselves execute on.

## Test plan
- [x] Local typecheck + test suite still green on main (verified at v1.5.0 release)
- [ ] CI workflow passes on this branch (Node 18/20/22 matrix)
- [ ] Merge does not require re-running publish — next release tag will exercise publish.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)