### PR TITLE
chore(ci): stamp supply chain policies via charter stamp-policies

### DIFF
--- a/.charter/config.json
+++ b/.charter/config.json
@@ -1,0 +1,8 @@
+{
+  "drift": {
+    "enabled": true,
+    "include": [
+      ".github/workflows/*.yml"
+    ]
+  }
+}

--- a/.charter/patterns/floating-action-pins.json
+++ b/.charter/patterns/floating-action-pins.json
@@ -1,0 +1,10 @@
+{
+  "id": "floating-action-pins",
+  "name": "Floating Action Pins",
+  "category": "SECURITY",
+  "status": "ACTIVE",
+  "anti_patterns": "uses: (?!Stackbilt-dev/)(?!\\./)[^@]+@v[\\d]",
+  "blessed_solution": "Pin to full commit SHA with a # vX.Y.Z comment: uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4",
+  "rationale": "Tag-based action pins are mutable — a supply chain attacker can move the tag to a malicious commit. SHA pins are immutable.",
+  "created_at": "2026-05-20T00:00:00.000Z"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         node-version: [18, 20, 22]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci --ignore-scripts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,8 @@ jobs:
       contents: read
       id-token: write  # Required for npm provenance
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,18 @@
+name: Supply Chain
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  sbom:
+    uses: Stackbilt-dev/stackbilt_llc/.github/workflows/supply-chain-sbom.yml@006a05aa3f37966207e0a2068a947715a91536be
+    with:
+      node-version: '22'
+      package-manager: 'npm'
+
+  dep-review:
+    if: github.event_name == 'pull_request'
+    uses: Stackbilt-dev/stackbilt_llc/.github/workflows/supply-chain-dep-review.yml@006a05aa3f37966207e0a2068a947715a91536be

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   sbom:
-    uses: Stackbilt-dev/stackbilt_llc/.github/workflows/supply-chain-sbom.yml@006a05aa3f37966207e0a2068a947715a91536be
+    uses: Stackbilt-dev/stackbilt_llc/.github/workflows/supply-chain-sbom.yml@c87defbe10de10c7d53653338d330bcd48d41746
     with:
       node-version: '22'
       package-manager: 'npm'
 
   dep-review:
     if: github.event_name == 'pull_request'
-    uses: Stackbilt-dev/stackbilt_llc/.github/workflows/supply-chain-dep-review.yml@006a05aa3f37966207e0a2068a947715a91536be
+    uses: Stackbilt-dev/stackbilt_llc/.github/workflows/supply-chain-dep-review.yml@c87defbe10de10c7d53653338d330bcd48d41746


### PR DESCRIPTION
## Summary

- SHA-pins 4 floating action tags (`actions/checkout@v6`, `actions/setup-node@v6`) in `ci.yml` and `publish.yml` to verified commit SHAs
- Adds `.github/workflows/supply-chain.yml`: SBOM generation + dependency review callers sourced from `Stackbilt-dev/stackbilt_llc` reusable workflows (pinned to `006a05aa`)
- Installs `.charter/patterns/floating-action-pins.json` drift guard — future floating pins will be caught by `charter drift`
- Enables charter drift scanning on `.github/workflows/*.yml`

## Applied via

```bash
charter stamp-policies \
  --path . \
  --policy-repo-ref 006a05aa3f37966207e0a2068a947715a91536be
```

## Test plan

- [ ] CI passes on this branch
- [ ] SBOM artifact uploads on push to main after merge
- [ ] Dep-review runs (and blocks on HIGH severity) on subsequent PRs
- [ ] `charter drift --path .` reports zero `floating-action-pins` violations

> **Note:** Cross-repo reusable workflows in a private GitHub org require:
> Org Settings → Actions → General → "Allow all actions and reusable workflows"

Governed-By: Stackbilt-dev/stackbilt_llc#11

🤖 Generated with [Claude Code](https://claude.com/claude-code)