### PR TITLE
feat(groq): catalog groq/compound + RESEARCH use-case tag (#69 S3)

### DIFF
--- a/src/__tests__/model-catalog.test.ts
+++ b/src/__tests__/model-catalog.test.ts
@@ -9,8 +9,10 @@ import {
   getRecommendedModel,
   getRoutingInfo,
   inferUseCaseFromRequest,
+  rankModels,
   type ModelRecommendationUseCase,
 } from '../model-catalog';
+import { MODELS } from '../index';
 import type { CircuitBreakerState, LLMRequest } from '../types';
 
 function closedState(): CircuitBreakerState {
@@ -238,10 +240,11 @@ describe('getProvidersForCatalogModel', () => {
 
   it('returns a single provider for an unambiguous model', () => {
     expect(getProvidersForCatalogModel('llama-3.3-70b-versatile')).toEqual(['groq']);
+    // groq/compound is catalogued under Groq as of S3.
+    expect(getProvidersForCatalogModel('groq/compound')).toEqual(['groq']);
   });
 
   it('returns an empty array for an unknown model', () => {
-    expect(getProvidersForCatalogModel('groq/compound')).toEqual([]);
     expect(getProvidersForCatalogModel('not-a-real-model')).toEqual([]);
   });
 });
@@ -263,5 +266,66 @@ describe('modelSupportsBuiltInTools', () => {
   it('is false for function-only models and unknown pairs', () => {
     expect(modelSupportsBuiltInTools('llama-3.3-70b-versatile', 'groq')).toBe(false);
     expect(modelSupportsBuiltInTools('not-a-real-model', 'groq')).toBe(false);
+  });
+
+  it('advertises all five built-in tools for both Compound systems', () => {
+    for (const model of ['groq/compound', 'groq/compound-mini']) {
+      for (const tool of ['web_search', 'visit_website', 'browser_automation', 'code_interpreter', 'wolfram_alpha']) {
+        expect(modelSupportsBuiltInTools(model, 'groq', tool)).toBe(true);
+      }
+    }
+  });
+});
+
+describe('groq/compound catalog entries (S3)', () => {
+  it('catalogues groq/compound and groq/compound-mini under Groq, active, RESEARCH-tagged', () => {
+    for (const model of ['groq/compound', 'groq/compound-mini']) {
+      const entry = getCatalogEntry(model);
+      expect(entry).toBeDefined();
+      expect(entry?.provider).toBe('groq');
+      expect(entry?.lifecycle).toBe('active');
+      expect(entry?.useCases).toContain('RESEARCH');
+      expect(entry?.capabilities.supportsTools).toBe(true);
+    }
+  });
+
+  it('recommends a Compound system for the RESEARCH use case, full Compound first', () => {
+    const ranked = rankModels('RESEARCH', ['groq']);
+    expect(ranked[0]?.model).toBe('groq/compound');
+    expect(ranked.map(e => e.model)).toContain('groq/compound-mini');
+  });
+
+  it('lists both Compound systems under MODEL_RECOMMENDATIONS.RESEARCH', () => {
+    expect(MODEL_RECOMMENDATIONS.RESEARCH).toEqual(
+      expect.arrayContaining(['groq/compound', 'groq/compound-mini'])
+    );
+  });
+
+  // AC #6: existing callers must not silently route to a Compound system — Groq
+  // auto-enables web_search on those models, so generic traffic landing there
+  // would incur search surcharges. Compound is tagged RESEARCH-only; verify it
+  // never wins a generic groq-only recommendation.
+  it('does NOT select a Compound system for generic use cases on a groq-only setup', () => {
+    for (const useCase of ['TOOL_CALLING', 'HIGH_PERFORMANCE', 'BALANCED', 'COST_EFFECTIVE', 'LONG_CONTEXT'] as const) {
+      const recommended = getRecommendedModel(useCase, ['groq']);
+      expect(recommended).not.toBe('groq/compound');
+      expect(recommended).not.toBe('groq/compound-mini');
+    }
+  });
+
+  it('exports MODELS.GROQ_COMPOUND / GROQ_COMPOUND_MINI pointing at catalogued models', () => {
+    expect(MODELS.GROQ_COMPOUND).toBe('groq/compound');
+    expect(MODELS.GROQ_COMPOUND_MINI).toBe('groq/compound-mini');
+    expect(getCatalogEntry(MODELS.GROQ_COMPOUND)).toBeDefined();
+    expect(getCatalogEntry(MODELS.GROQ_COMPOUND_MINI)).toBeDefined();
+  });
+
+  it('does not infer RESEARCH from request shape — it is opt-in via pinned model or metadata.useCase', () => {
+    // A plain research-flavoured prompt with tools still infers TOOL_CALLING.
+    const request: Partial<LLMRequest> = {
+      messages: [{ role: 'user', content: 'Find authoritative sources on a topic.' }],
+      builtInTools: [{ type: 'web_search' }],
+    };
+    expect(inferUseCaseFromRequest(request)).not.toBe('RESEARCH');
   });
 });

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -785,11 +785,12 @@ export class LLMProviderFactory {
       return 'cloudflare';
     }
 
-    // Groq models. `openai/gpt-oss-120b` is Groq-hosted (also handled above via
-    // the catalog), and the `groq/` namespace (`groq/compound`,
-    // `groq/compound-mini`) is Groq-unique — route it before a full catalog
-    // entry exists so the system model doesn't fall through to a substituted
-    // default on another provider.
+    // Groq models. These are normally resolved via the catalog path above
+    // (`llama-3.3-70b-versatile`, `openai/gpt-oss-120b`, `groq/compound`,
+    // `groq/compound-mini` all have catalog entries). This heuristic is the
+    // fallback for any future Groq model string not yet catalogued — the
+    // `groq/` namespace is Groq-unique, so route it here rather than letting it
+    // fall through to a substituted default on another provider.
     if (model.includes('-versatile') || model.includes('-instant')
         || model === 'openai/gpt-oss-120b' || model.startsWith('groq/')) {
       return 'groq';
@@ -1272,7 +1273,8 @@ export class LLMProviderFactory {
         normalized === 'BALANCED' ||
         normalized === 'TOOL_CALLING' ||
         normalized === 'LONG_CONTEXT' ||
-        normalized === 'VISION'
+        normalized === 'VISION' ||
+        normalized === 'RESEARCH'
       ) {
         return normalized;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -502,6 +502,8 @@ export const MODELS = {
   GROQ_LLAMA_3_3_70B_VERSATILE: 'llama-3.3-70b-versatile',
   GROQ_LLAMA_3_1_8B_INSTANT: 'llama-3.1-8b-instant',
   GROQ_GPT_OSS_120B: 'openai/gpt-oss-120b',
+  GROQ_COMPOUND: 'groq/compound',
+  GROQ_COMPOUND_MINI: 'groq/compound-mini',
 
   // NVIDIA NIM models
   NVIDIA_LLAMA_3_3_70B: 'meta/llama-3.3-70b-instruct',

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -9,7 +9,8 @@ export type ModelRecommendationUseCase =
   | 'BALANCED'
   | 'TOOL_CALLING'
   | 'LONG_CONTEXT'
-  | 'VISION';
+  | 'VISION'
+  | 'RESEARCH';
 
 export interface ModelCatalogEntry {
   provider: ProviderName;
@@ -445,6 +446,47 @@ export const MODEL_CATALOG: readonly ModelCatalogEntry[] = [
     supportsBuiltInTools: ['web_search', 'code_interpreter'],
     description: 'Groq GPT-OSS 120B'
   }, { speed: 5, quality: 4, cost: 4 }),
+  // Groq Compound systems (issue #69): server-side agentic systems that route
+  // between backing models and natively run all five built-in tools. Same
+  // `/chat/completions` endpoint — no new HTTP path. Token costs are an estimate
+  // (roll-up of Llama 4 Scout 17B / GPT-OSS 120B); built-in surcharges
+  // (web_search $5/1k req, code_interpreter $0.18/hr, browser_automation
+  // $0.08/hr) are billed separately and are NOT token-tracked here.
+  //
+  // Tagged RESEARCH-only — deliberately NOT TOOL_CALLING/HIGH_PERFORMANCE/etc.
+  // despite supporting function tools. Compound autonomously runs web_search as
+  // part of its routing, so any generic traffic that landed here risks
+  // unpredictable per-search surcharges. Keeping them out of the generic
+  // recommendation pools means they are only auto-selected when a caller asks
+  // for RESEARCH explicitly (or pins the model, the intended path).
+  //
+  // costScore 1 (most expensive) on both reflects that surcharge-inflated
+  // effective cost — and structurally keeps them below the generic groq lineup
+  // in every non-RESEARCH pool, including LONG_CONTEXT where no groq model
+  // carries a tag bonus and the slightly larger window would otherwise edge them
+  // ahead. Full Compound outranks Mini for RESEARCH via its higher qualityScore.
+  entry('groq', 'groq/compound', 'active', ['RESEARCH'], {
+    maxContextLength: 131072,
+    supportsStreaming: true,
+    supportsTools: true,
+    supportsBatching: false,
+    inputTokenCost: 0.00015,
+    outputTokenCost: 0.0006,
+    supportsBuiltInTools: ['web_search', 'visit_website', 'browser_automation', 'code_interpreter', 'wolfram_alpha'],
+    supportsVision: false,
+    description: 'Groq Compound — agentic system routing Llama 4 Scout (17B) / GPT-OSS 120B by query complexity; runs all five built-in tools server-side. Token cost estimated; built-in tool surcharges billed separately, not token-tracked.'
+  }, { speed: 4, quality: 5, cost: 1 }),
+  entry('groq', 'groq/compound-mini', 'active', ['RESEARCH'], {
+    maxContextLength: 131072,
+    supportsStreaming: true,
+    supportsTools: true,
+    supportsBatching: false,
+    inputTokenCost: 0.0001,
+    outputTokenCost: 0.0004,
+    supportsBuiltInTools: ['web_search', 'visit_website', 'browser_automation', 'code_interpreter', 'wolfram_alpha'],
+    supportsVision: false,
+    description: 'Groq Compound Mini — lower-latency single-pass variant of Compound; same five built-in tools. Token cost estimated; built-in tool surcharges billed separately, not token-tracked.'
+  }, { speed: 5, quality: 4, cost: 1 }),
 
   // NVIDIA NIM — costs are zero placeholders (dev-tier credit-based; production
   // pricing varies by model). Update inputTokenCost/outputTokenCost via CreditLedger.
@@ -564,6 +606,11 @@ function scoreUseCase(entry: ModelCatalogEntry, useCase: ModelRecommendationUseC
     TOOL_CALLING: { cost: 2, speed: 3, quality: 5 },
     LONG_CONTEXT: { cost: 2, speed: 2, quality: 4 },
     VISION: { cost: 2, speed: 2, quality: 4 },
+    // Research favours model quality strongly over cost/speed — the workload is
+    // authoritative-source gathering, where a better backing model and richer
+    // built-in-tool routing matter more than latency. Quality-dominant so full
+    // Compound ranks above Compound Mini for the same RESEARCH request.
+    RESEARCH: { cost: 1, speed: 2, quality: 6 },
   } as const;
 
   const weight = weights[useCase];
@@ -876,4 +923,5 @@ export const MODEL_RECOMMENDATIONS = {
   TOOL_CALLING: activeModelsFor('TOOL_CALLING'),
   LONG_CONTEXT: activeModelsFor('LONG_CONTEXT'),
   VISION: activeModelsFor('VISION'),
+  RESEARCH: activeModelsFor('RESEARCH'),
 } as const;


### PR DESCRIPTION
Implements **S3** of the Groq built-in-tools sprint (#69), stacked on the merged S0–S2 foundation (#70).

## What

- Adds `groq/compound` and `groq/compound-mini` to `MODEL_CATALOG` (active, Groq, all five built-in tools, vision off).
- Introduces the `RESEARCH` `ModelRecommendationUseCase` — fully wired, not dead metadata:
  - enum member
  - `scoreUseCase` weights (quality-dominant)
  - `MODEL_RECOMMENDATIONS.RESEARCH` list
  - accepted in `factory.resolveUseCase()` via `metadata.useCase`
- Exports `MODELS.GROQ_COMPOUND` / `MODELS.GROQ_COMPOUND_MINI`.

## ⚠️ Deliberate deviation from the issue's example tags — reviewer veto point

Issue #69 illustrated the entries as `['TOOL_CALLING','RESEARCH','HIGH_PERFORMANCE']` (compound) and `['TOOL_CALLING','RESEARCH','COST_EFFECTIVE']` (mini). **Both ship `['RESEARCH']`-only here.**

Reason: Compound *autonomously runs `web_search`* as part of its routing, so any generic traffic that auto-selected these models would risk unpredictable per-search surcharges (`web_search` $5/1k req). RESEARCH-only tagging keeps them out of the generic recommendation pools — they're only auto-selected when a caller asks for `RESEARCH` explicitly or pins the model (the intended consumer path from the issue). The AC only mandates the `RESEARCH` tag, which is satisfied.

If you'd rather honor the example tags verbatim, this is the line to push back on.

## Routing safety

- `costScore: 1` on both (honest — surcharges make effective cost highest in the Groq lineup) also structurally keeps them below the generic Groq models in **every** non-RESEARCH pool, including `LONG_CONTEXT` where no Groq model carries a tag bonus and the slightly larger context window would otherwise edge them ahead.
- A regression guard test asserts no Compound system wins any generic groq-only recommendation (`TOOL_CALLING`/`HIGH_PERFORMANCE`/`BALANCED`/`COST_EFFECTIVE`/`LONG_CONTEXT`) — the empirical check on AC #6 ("existing callers unchanged").
- `RESEARCH` is **not** inferred from request shape (opt-in only) — no silent re-routing of existing traffic.

## Caveats

- Token costs are estimates (roll-up of Llama 4 Scout / GPT-OSS 120B); built-in tool surcharges are **not** token-tracked in v1 (consistent with the issue's out-of-scope note).

## Tests

typecheck clean; **391 pass (+7 new)** covering catalog entries, RESEARCH ranking (full Compound first), `MODEL_RECOMMENDATIONS.RESEARCH`, the generic-pool regression guard, `MODELS.*` exports, and the no-inference guarantee.

Next: S4 (adapter request fork + boundary gating), S5 (`executed_tools` → `metadata.builtInToolResults`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)