### PR TITLE
feat(groq): built-in-tools request fork + boundary gating (#69 S4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to `@stackbilt/llm-providers` are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+Groq built-in tools (issue #69), landing across stacked PRs. Additive only.
+
+### Added
+- **`LLMRequest.builtInTools`** — optional `Array<{ type: BuiltInToolType }>` requesting server-side tools (web search, code interpreter, etc.). Normalized identifiers: `web_search`, `visit_website`, `browser_automation`, `code_interpreter`, `wolfram_alpha`. Ignored by providers/models that don't advertise `supportsBuiltInTools`.
+- **`BuiltInTool`, `BuiltInToolType`, `BuiltInToolResult` types** — exported from package root. `BuiltInToolResult` mirrors Groq's `executed_tools[]` (`{ type, name?, arguments?, results: [{ title, url, content, score }] }`); `type` is provider-native and open-ended.
+- **`ModelCapabilities.supportsBuiltInTools`** — per-model list of built-in tools a (model, provider) pair advertises; drives capability-aware routing and boundary gating.
+- **`modelSupportsBuiltInTools(model, provider, tool?)`** — catalog accessor; the single source of truth for built-in-tool gating.
+- **`groq/compound` + `groq/compound-mini` catalog entries** — Groq Compound systems (all five built-in tools), tagged `RESEARCH`-only so they stay out of generic recommendation pools (selecting a Compound model can incur per-search surcharges). `MODELS.GROQ_COMPOUND` / `MODELS.GROQ_COMPOUND_MINI` exported.
+- **`RESEARCH` `ModelRecommendationUseCase`** — new use case with `scoreUseCase` weights and a `MODEL_RECOMMENDATIONS.RESEARCH` list; honored by `factory.resolveUseCase()` via `metadata.useCase`. Not inferred from request shape (opt-in only).
+- **Capability-aware built-in-tools routing** — `openai/gpt-oss-120b` is hosted by both Cerebras and Groq; a `builtInTools` request is steered to Groq (the capable host) while plain requests keep the prior default. Resolves the catalog collision via `getProvidersForCatalogModel`.
+- **Groq built-in-tools request fork + boundary gating** — Compound systems send tools on `compound_custom.tools.enabled_tools` (identifiers verbatim); `openai/gpt-oss-120b` sends OpenAI-style `tools: [{ type }]` with `web_search` → `browser_search` translation, merged alongside function tools. Unsupported `(model, tool)` pairs throw `ConfigurationError` naming the capable models.
+
+### Notes
+- Built-in tool surcharges are billed by the provider and are **not** attributed per-call in `TokenUsage`; use `CreditLedger` for accounting.
+- Structured result surfacing (`metadata.builtInToolResults`) for the Groq adapter is being wired in a follow-up PR; the request path and gating are complete.
+
 ## [1.9.0] — 2026-05-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A multi-provider LLM abstraction layer with automatic failover, graduated circui
 - **Streaming with fallback** -- SSE streaming on all providers; factory-level streaming routes through the same circuit-breaker and fallback chain as non-streaming requests
 - **Tool/function calling** -- OpenAI, Anthropic, Cerebras, and Cloudflare tool use with unified response format
 - **Tool-use loop helper** -- `generateResponseWithTools` owns the request → parse → execute → repeat cycle with iteration caps, cost limits, abort signal support, and `onIteration` early-exit via `{ abort: true }`
+- **Server-side built-in tools** -- `LLMRequest.builtInTools` (e.g. `[{ type: 'web_search' }]`) drives Groq's Compound systems and GPT-OSS 120B to run web search / code interpreter server-side; capability-gated per model and routed to the capable provider automatically
 - **Routing introspection** -- `getRoutingInfo()` returns a pre-flight routing snapshot (use case, provider, model, token estimate, lifecycle, deprecation warning) without dispatching the request; pairs with `request.metadata.useCase` to pre-classify intent at the gateway and let the catalog drive dispatch
 - **Deprecation annotations** -- `generateResponse()` attaches `metadata.llmProvidersDeprecationWarning` to every response that uses a non-active-lifecycle model
 - **Provider-agnostic cache hints** -- `LLMRequest.cache` translates to provider-native caching (Anthropic `cache_control` breakpoints; automatic on OpenAI/Groq/Cerebras); cached token counts normalized into `TokenUsage`
@@ -83,7 +84,7 @@ const llm = LLMProviders.fromEnv(env, {
 | **Anthropic** | Claude Opus 4.6, Sonnet 4.6, Sonnet 4, Haiku 4.5, 3.7 Sonnet, 3.5 Sonnet/Haiku, 3 Opus/Sonnet | Yes | Yes | Default: `claude-haiku-4-5-20251001` |
 | **Cloudflare** | Gemma 4 26B, Llama 4 Scout, GPT-OSS 120B, LLaMA 3.x, Mistral 7B, Qwen 1.5, TinyLlama, and more | Yes | GPT-OSS, Gemma 4, Llama 4 Scout | Default is request-aware and catalog-driven |
 | **Cerebras** | GPT-OSS 120B, ZAI-GLM 4.7, LLaMA 3.1 8B *(deprecated 2026-05-27)*, Qwen 3 235B *(deprecated 2026-05-27)* | Yes | GLM, Qwen, GPT-OSS | ~2,200 tok/s |
-| **Groq** | LLaMA 3.3 70B Versatile, LLaMA 3.1 8B Instant, GPT-OSS 120B | Yes | LLaMA 3.3 70B, GPT-OSS 120B | Ultra-fast inference |
+| **Groq** | LLaMA 3.3 70B Versatile, LLaMA 3.1 8B Instant, GPT-OSS 120B, Compound, Compound Mini | Yes | LLaMA 3.3 70B, GPT-OSS 120B | Ultra-fast inference; Compound systems run built-in tools |
 | **NVIDIA NIM** | Llama 3.3/3.1 70B, Llama 4 Maverick, Nemotron 70B/49B/253B, Mistral Large 2, DeepSeek V4 Flash/Pro | Yes | Llama, Nemotron, Mistral Large 2 | Costs $0 placeholder — dev-tier credits; set real rates in `CreditLedger` |
 
 ### Provider Configuration
@@ -330,6 +331,8 @@ MODELS.CLAUDE_HAIKU_4_5;        // 'claude-haiku-4-5-20251001'
 MODELS.GPT_4O;                  // 'gpt-4o' (deprecated / compatibility only)
 MODELS.GPT_4O_MINI;             // 'gpt-4o-mini'
 MODELS.CEREBRAS_ZAI_GLM_4_7;    // 'zai-glm-4.7'
+MODELS.GROQ_COMPOUND;           // 'groq/compound' (RESEARCH; built-in tools)
+MODELS.GROQ_COMPOUND_MINI;      // 'groq/compound-mini'
 MODELS.NVIDIA_NEMOTRON_70B;     // 'nvidia/llama-3.1-nemotron-70b-instruct'
 MODELS.NVIDIA_LLAMA_4_MAVERICK; // 'meta/llama-4-maverick-17b-128e-instruct'
 
@@ -395,6 +398,35 @@ const result = await llm.generateResponseWithTools(
 
 console.log(result.message); // final assistant response after tool execution
 ```
+
+## Built-in Tools (Server-Side)
+
+Some models run tools **server-side** — the provider executes web search, code interpretation, etc. inside a single completion call, no execute callback required. Set `LLMRequest.builtInTools` with normalized identifiers; the adapter translates to each model family's native wire shape and rejects unsupported combinations at the boundary.
+
+```typescript
+import { LLMProviders, MODELS } from '@stackbilt/llm-providers';
+
+const llm = LLMProviders.fromEnv(env);
+const res = await llm.generateResponse({
+  model: MODELS.GROQ_COMPOUND,                 // 'groq/compound'
+  messages: [{ role: 'user', content: 'Find authoritative sources on topic X.' }],
+  builtInTools: [{ type: 'web_search' }],
+});
+```
+
+Normalized identifiers: `web_search`, `visit_website`, `browser_automation`, `code_interpreter`, `wolfram_alpha`.
+
+| Model | Built-in tools | Wire shape |
+|-------|----------------|------------|
+| `groq/compound`, `groq/compound-mini` | all five | `compound_custom.tools.enabled_tools` (identifiers verbatim) |
+| `openai/gpt-oss-120b` (Groq) | `web_search`, `code_interpreter` | OpenAI-style `tools: [{ type }]`, `web_search` → `browser_search` |
+| all other models | — | rejected with `ConfigurationError` naming the capable models |
+
+Notes:
+- **Capability-aware routing.** `openai/gpt-oss-120b` is hosted by both Cerebras and Groq; only Groq runs built-in tools, so a `builtInTools` request is steered to Groq automatically. Plain requests keep the default routing.
+- **Provenance.** The Compound systems are tagged `RESEARCH`-only in the catalog and are not auto-selected for generic use cases — pin the model (or request the `RESEARCH` use case) to use them, since selecting a Compound model can incur per-search surcharges.
+- **Cost.** Built-in tool surcharges (e.g. web search ~$5/1k requests) are billed by the provider and are **not** attributed per-call in `TokenUsage`; track them via `CreditLedger` if needed.
+- **Citations.** Structured search results surface on `LLMResponse.metadata.builtInToolResults` (`{ type, name?, arguments?, results: [{ title, url, content, score }] }`). Result parsing for the Groq adapter is being wired in a follow-up; the request path and gating described here are live today.
 
 ## Prompt Cache Hints
 

--- a/src/__tests__/groq.test.ts
+++ b/src/__tests__/groq.test.ts
@@ -70,7 +70,13 @@ describe('GroqProvider', () => {
   describe('getModels', () => {
     it('should return available models', () => {
       const models = provider.getModels();
-      expect(models).toEqual(['llama-3.3-70b-versatile', 'llama-3.1-8b-instant', 'openai/gpt-oss-120b']);
+      expect(models).toEqual([
+        'llama-3.3-70b-versatile',
+        'llama-3.1-8b-instant',
+        'openai/gpt-oss-120b',
+        'groq/compound',
+        'groq/compound-mini',
+      ]);
     });
 
     it('should return a copy of the models array', () => {
@@ -450,6 +456,137 @@ describe('GroqProvider', () => {
 
       const body = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(body.tools).toHaveLength(1);
+    });
+  });
+
+  describe('built-in tools (S4)', () => {
+    const okResponse = (model: string) => ({
+      ok: true,
+      json: async () => ({
+        id: 'chatcmpl-bi-1',
+        object: 'chat.completion',
+        created: 1700000000,
+        model,
+        choices: [{ index: 0, message: { role: 'assistant', content: 'done' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 }
+      }),
+      headers: new Headers({ 'content-type': 'application/json' })
+    });
+
+    it('forks web_search onto compound_custom.tools.enabled_tools for groq/compound', async () => {
+      mockFetch.mockResolvedValueOnce(okResponse('groq/compound'));
+
+      await provider.generateResponse({
+        messages: [{ role: 'user', content: 'Find sources on X.' }],
+        model: 'groq/compound',
+        builtInTools: [{ type: 'web_search' }],
+        maxTokens: 100,
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.compound_custom).toEqual({ tools: { enabled_tools: ['web_search'] } });
+      // Compound does NOT use the OpenAI-style tools array for built-ins.
+      expect(body.tools).toBeUndefined();
+    });
+
+    it('passes all five normalized identifiers verbatim to compound', async () => {
+      mockFetch.mockResolvedValueOnce(okResponse('groq/compound-mini'));
+
+      await provider.generateResponse({
+        messages: [{ role: 'user', content: 'Research.' }],
+        model: 'groq/compound-mini',
+        builtInTools: [
+          { type: 'web_search' },
+          { type: 'visit_website' },
+          { type: 'browser_automation' },
+          { type: 'code_interpreter' },
+          { type: 'wolfram_alpha' },
+        ],
+        maxTokens: 100,
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.compound_custom.tools.enabled_tools).toEqual([
+        'web_search', 'visit_website', 'browser_automation', 'code_interpreter', 'wolfram_alpha',
+      ]);
+    });
+
+    it('translates web_search → browser_search on the gpt-oss tools array', async () => {
+      mockFetch.mockResolvedValueOnce(okResponse('openai/gpt-oss-120b'));
+
+      await provider.generateResponse({
+        messages: [{ role: 'user', content: 'Find sources on X.' }],
+        model: 'openai/gpt-oss-120b',
+        builtInTools: [{ type: 'web_search' }],
+        maxTokens: 100,
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.tools).toEqual([{ type: 'browser_search' }]);
+      expect(body.compound_custom).toBeUndefined();
+    });
+
+    it('merges built-in tools alongside function tools on gpt-oss', async () => {
+      mockFetch.mockResolvedValueOnce(okResponse('openai/gpt-oss-120b'));
+
+      await provider.generateResponse({
+        messages: [{ role: 'user', content: 'Weather then search.' }],
+        model: 'openai/gpt-oss-120b',
+        tools: [{
+          type: 'function',
+          function: { name: 'get_weather', description: 'Weather', parameters: { type: 'object' } }
+        }],
+        builtInTools: [{ type: 'web_search' }],
+        maxTokens: 100,
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      const types = body.tools.map((t: { type: string }) => t.type);
+      expect(types).toContain('function');
+      expect(types).toContain('browser_search');
+    });
+
+    it('rejects built-in tools on a function-only model, naming capable models', async () => {
+      await expect(provider.generateResponse({
+        messages: [{ role: 'user', content: 'hi' }],
+        model: 'llama-3.3-70b-versatile',
+        builtInTools: [{ type: 'web_search' }],
+        maxTokens: 100,
+      })).rejects.toThrow(ConfigurationError);
+
+      await expect(provider.generateResponse({
+        messages: [{ role: 'user', content: 'hi' }],
+        model: 'llama-3.3-70b-versatile',
+        builtInTools: [{ type: 'web_search' }],
+        maxTokens: 100,
+      })).rejects.toThrow(/groq\/compound/);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unsupported tool on gpt-oss, naming its supported subset', async () => {
+      await expect(provider.generateResponse({
+        messages: [{ role: 'user', content: 'hi' }],
+        model: 'openai/gpt-oss-120b',
+        builtInTools: [{ type: 'wolfram_alpha' }],
+        maxTokens: 100,
+      })).rejects.toThrow(/web_search/);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('accepts a pinned groq/compound model through validateRequest', async () => {
+      mockFetch.mockResolvedValueOnce(okResponse('groq/compound'));
+
+      const response = await provider.generateResponse({
+        messages: [{ role: 'user', content: 'Research.' }],
+        model: 'groq/compound',
+        builtInTools: [{ type: 'web_search' }],
+        maxTokens: 100,
+      });
+
+      expect(response.provider).toBe('groq');
+      expect(mockFetch).toHaveBeenCalled();
     });
   });
 

--- a/src/__tests__/groq.test.ts
+++ b/src/__tests__/groq.test.ts
@@ -547,19 +547,17 @@ describe('GroqProvider', () => {
     });
 
     it('rejects built-in tools on a function-only model, naming capable models', async () => {
-      await expect(provider.generateResponse({
+      // Single invocation, asserted twice — a second generateResponse call would
+      // accumulate a circuit-breaker failure and mask the ConfigurationError.
+      const promise = provider.generateResponse({
         messages: [{ role: 'user', content: 'hi' }],
         model: 'llama-3.3-70b-versatile',
         builtInTools: [{ type: 'web_search' }],
         maxTokens: 100,
-      })).rejects.toThrow(ConfigurationError);
+      });
 
-      await expect(provider.generateResponse({
-        messages: [{ role: 'user', content: 'hi' }],
-        model: 'llama-3.3-70b-versatile',
-        builtInTools: [{ type: 'web_search' }],
-        maxTokens: 100,
-      })).rejects.toThrow(/groq\/compound/);
+      await expect(promise).rejects.toBeInstanceOf(ConfigurationError);
+      await expect(promise).rejects.toThrow(/groq\/compound/);
 
       expect(mockFetch).not.toHaveBeenCalled();
     });

--- a/src/providers/groq.ts
+++ b/src/providers/groq.ts
@@ -3,7 +3,7 @@
  * Implementation for Groq fast inference models (OpenAI-compatible API)
  */
 
-import type { LLMRequest, LLMResponse, GroqConfig, ModelCapabilities, ProviderBalance, ToolCall, TokenUsage } from '../types.js';
+import type { LLMRequest, LLMResponse, GroqConfig, ModelCapabilities, ProviderBalance, ToolCall, TokenUsage, BuiltInTool, BuiltInToolType } from '../types.js';
 import { BaseProvider } from './base.js';
 import {
   LLMErrorFactory,
@@ -11,7 +11,7 @@ import {
   ConfigurationError,
   SchemaDriftError
 } from '../errors.js';
-import { getProviderDefaultModel } from '../model-catalog.js';
+import { getProviderDefaultModel, getCatalogEntry, modelSupportsBuiltInTools } from '../model-catalog.js';
 import { validateSchema, type SchemaField } from '../utils/schema-validator.js';
 
 // Groq serves the OpenAI /chat/completions contract — same envelope shape as
@@ -60,7 +60,7 @@ interface GroqMessage {
   tool_call_id?: string;
 }
 
-interface GroqTool {
+interface GroqFunctionTool {
   type: 'function';
   function: {
     name: string;
@@ -68,6 +68,15 @@ interface GroqTool {
     parameters: Record<string, unknown>;
   };
 }
+
+// Built-in tool entry on the OpenAI-compatible `tools` array, used by the
+// gpt-oss path (e.g. `{ type: 'browser_search' }`). `type` is the provider's
+// native wire identifier, not our normalized `BuiltInToolType`.
+interface GroqBuiltInTool {
+  type: string;
+}
+
+type GroqTool = GroqFunctionTool | GroqBuiltInTool;
 
 interface GroqRequest {
   model: string;
@@ -80,6 +89,10 @@ interface GroqRequest {
     | { type: 'json_schema'; json_schema: { name: string; schema: Record<string, unknown>; strict?: boolean } };
   tools?: GroqTool[];
   tool_choice?: 'auto' | 'none' | { type: 'function'; function: { name: string } };
+  // Compound systems (groq/compound*) configure built-in tools here rather than
+  // on the OpenAI-style `tools` array. `enabled_tools` takes Groq's compound
+  // vocabulary, which equals our normalized BuiltInToolType identifiers.
+  compound_custom?: { tools: { enabled_tools: string[] } };
   seed?: number;
 }
 
@@ -119,12 +132,28 @@ const TOOL_CAPABLE_MODELS = new Set([
   'llama-3.3-70b-versatile',
 ]);
 
+// Compound systems configure built-in tools via `compound_custom.tools`, taking
+// the normalized identifiers verbatim. Every other capable model (gpt-oss) uses
+// the OpenAI-style `tools` array with a different vocabulary.
+const COMPOUND_MODELS = new Set(['groq/compound', 'groq/compound-mini']);
+
+// Translate normalized BuiltInToolType → gpt-oss native wire identifier. Only
+// the tools the catalog advertises for gpt-oss appear here; the capability gate
+// (modelSupportsBuiltInTools) runs first, so a missing key after the gate passes
+// is an internal map/catalog drift, not a caller error.
+const GPT_OSS_BUILTIN_WIRE: Partial<Record<BuiltInToolType, string>> = {
+  web_search: 'browser_search',
+  code_interpreter: 'code_interpreter',
+};
+
 export class GroqProvider extends BaseProvider {
   name = 'groq';
   models = [
     'llama-3.3-70b-versatile',
     'llama-3.1-8b-instant',
     'openai/gpt-oss-120b',
+    'groq/compound',
+    'groq/compound-mini',
   ];
   supportsStreaming = true;
   supportsTools = true;
@@ -243,6 +272,27 @@ export class GroqProvider extends BaseProvider {
         inputTokenCost: 0.00015, // $0.15 per 1M tokens (cached: $0.075/MTok)
         outputTokenCost: 0.0006,  // $0.60 per 1M tokens
         description: 'GPT-OSS 120B - OpenAI-compatible tool calling on Groq'
+      },
+      // Compound systems: token costs are estimates (roll-up of the backing
+      // models); built-in tool surcharges are billed separately and not
+      // token-tracked. See model-catalog.ts for the routing rationale.
+      'groq/compound': {
+        maxContextLength: 131072,
+        supportsStreaming: true,
+        supportsTools: true,
+        supportsBatching: false,
+        inputTokenCost: 0.00015,
+        outputTokenCost: 0.0006,
+        description: 'Groq Compound - agentic system with server-side built-in tools'
+      },
+      'groq/compound-mini': {
+        maxContextLength: 131072,
+        supportsStreaming: true,
+        supportsTools: true,
+        supportsBatching: false,
+        inputTokenCost: 0.0001,
+        outputTokenCost: 0.0004,
+        description: 'Groq Compound Mini - lower-latency built-in-tools system'
       }
     };
   }
@@ -456,7 +506,68 @@ export class GroqProvider extends BaseProvider {
       }
     }
 
+    // Built-in tools (web_search etc.) — gated against the catalog and forked by
+    // model family. Runs independently of the function-tool path above; gpt-oss
+    // can carry both at once on the same `tools` array.
+    if (request.builtInTools && request.builtInTools.length > 0) {
+      this.applyBuiltInTools(groqRequest, model, request.builtInTools);
+    }
+
     return groqRequest;
+  }
+
+  /**
+   * Gate and serialize built-in tools onto a Groq request.
+   *
+   * Capability is checked against the catalog (`modelSupportsBuiltInTools`) so
+   * the adapter and catalog can't drift. The wire shape then forks by family:
+   * compound systems take the normalized identifiers on
+   * `compound_custom.tools.enabled_tools`; gpt-oss takes OpenAI-style
+   * `{ type }` entries on the shared `tools` array, translated to its native
+   * vocabulary (`web_search` → `browser_search`).
+   */
+  private applyBuiltInTools(
+    groqRequest: GroqRequest,
+    model: string,
+    builtInTools: BuiltInTool[]
+  ): void {
+    for (const tool of builtInTools) {
+      if (!modelSupportsBuiltInTools(model, 'groq', tool.type)) {
+        const supported = getCatalogEntry(model)?.capabilities.supportsBuiltInTools ?? [];
+        const detail = supported.length > 0
+          ? `Model '${model}' supports built-in tools [${supported.join(', ')}] but not '${tool.type}'.`
+          : `Model '${model}' does not support built-in tools on Groq.`;
+        throw new ConfigurationError(
+          this.name,
+          `${detail} Built-in tools require groq/compound or groq/compound-mini ` +
+          `(all tools), or openai/gpt-oss-120b (web_search, code_interpreter).`
+        );
+      }
+    }
+
+    if (COMPOUND_MODELS.has(model)) {
+      // Compound's enabled_tools vocabulary equals the normalized identifiers —
+      // no translation. Dedupe to keep the wire payload clean.
+      groqRequest.compound_custom = {
+        tools: { enabled_tools: [...new Set(builtInTools.map(t => t.type))] }
+      };
+      return;
+    }
+
+    // gpt-oss path: merge built-in entries into the OpenAI-style tools array.
+    const builtInEntries: GroqBuiltInTool[] = builtInTools.map(tool => {
+      const wireType = GPT_OSS_BUILTIN_WIRE[tool.type];
+      if (!wireType) {
+        // Gate passed but no wire mapping — catalog advertises a tool the
+        // translation map doesn't cover. Internal drift, not a caller error.
+        throw new ConfigurationError(
+          this.name,
+          `Internal: no Groq wire mapping for built-in tool '${tool.type}' on '${model}'`
+        );
+      }
+      return { type: wireType };
+    });
+    groqRequest.tools = [...(groqRequest.tools ?? []), ...builtInEntries];
   }
 
   private formatResponse(


### PR DESCRIPTION
Implements **S4** of the Groq built-in-tools sprint (#69), on top of the merged S3 catalog (#71).

## What

Forks the Groq adapter's request shape by model family and gates built-in tools at the boundary.

| Model family | Wire shape | Vocabulary |
|---|---|---|
| `groq/compound`, `groq/compound-mini` | `compound_custom.tools.enabled_tools: [...]` | normalized identifiers **verbatim** (compound's vocabulary _is_ the normalized set) |
| `openai/gpt-oss-120b` | OpenAI-style `tools: [{ type }]`, merged onto the same array as function tools | translated — `web_search` → `browser_search` |

## Gating reuses the catalog — no drift

The capability gate calls `modelSupportsBuiltInTools(model, 'groq', tool.type)` (the accessor S3 built) as the **single source of truth**, rather than a duplicate capability set in the adapter. Only the wire-translation map (`web_search`→`browser_search`) is local, since spelling isn't a catalog concern. The enforcement point is still the adapter (satisfies the issue review's "gating belongs in the adapter, not catalog-only" — the accessor takes `(model, provider)` explicitly, so pinned models that bypass routing are still gated).

- Unsupported `(model, tool)` → `ConfigurationError` naming the capable models and, for gpt-oss, its supported subset (`web_search, code_interpreter`).
- Gate-passed-but-unmapped tool → explicit internal error rather than emitting `{type: undefined}`.

## Also required — the `models` array

`base.validateRequest` rejects any pinned model not in the provider's `models` list **before** `formatRequest` runs, so `model: 'groq/compound'` would have thrown without this. Added both compound models there + matching `getModelCapabilities()` entries (token costs estimated; built-in surcharges not token-tracked, per issue scope).

## Deliberately not touched

- **`TOOL_CAPABLE_MODELS`** — compound's *function*-tool support is unverified from the S0 spike, so the conservative reject stands (built-in tools are a separate, gated path).
- **`GROQ_RESPONSE_SCHEMA`** — response parsing is S5. Confirmed `validateSchema` ignores undeclared fields, so the unchanged schema already passes a real `executed_tools` response.

## Tests

typecheck clean; **398 pass (+7 new)**: compound fork shape, five-tool verbatim passthrough, gpt-oss translation, function+built-in merge on one array, function-only-model rejection (names capable models), unsupported-tool-on-gpt-oss rejection (names subset), pinned-`groq/compound` accepted through `validateRequest`.

Next: **S5** — parse `executed_tools[].search_results.results` → `metadata.builtInToolResults`, extend `GROQ_RESPONSE_SCHEMA`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)