### PR TITLE
chore(release): v1.10.0 — Groq built-in tools (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to `@stackbilt/llm-providers` are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [1.10.0] — 2026-05-29
 
 Groq built-in tools (issue #69). Additive only.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stackbilt/llm-providers",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Multi-LLM failover with circuit breakers, cost tracking, and intelligent retry. Cloudflare Workers native.",
   "author": "Stackbilt <admin@stackbilt.dev>",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -456,7 +456,7 @@ export default LLMProviders;
 /**
  * Version and metadata
  */
-export const VERSION = '1.9.0';
+export const VERSION = '1.10.0';
 export const SUPPORTED_PROVIDERS = ['openai', 'anthropic', 'cloudflare', 'cerebras', 'groq', 'nvidia'] as const;
 
 /**


### PR DESCRIPTION
Cuts **v1.10.0**, releasing the Groq built-in-tools feature (issue #69) so downstream consumers (stackbilt-web Evidence Engine) can install it.

- `package.json` + `VERSION` constant → `1.10.0`
- CHANGELOG `[Unreleased]` → `[1.10.0] — 2026-05-29`

**Minor bump** — entirely additive (new `LLMRequest.builtInTools`, `BuiltInTool*` types, `supportsBuiltInTools`, `modelSupportsBuiltInTools`, `groq/compound`/`groq/compound-mini` catalog entries, `RESEARCH` use case, `MODELS.GROQ_COMPOUND/_MINI`, `executed_tools` → `metadata.builtInToolResults`). No breaking changes.

CI pre-publish gates verified locally: `build`, `typecheck`, **402 tests**, `test:package` (packs as `1.10.0`), `npm audit --omit=dev` (0 vulns).

On merge I'll create the GitHub Release `v1.10.0`, which triggers `publish.yml` → OIDC provenance publish to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)