### PR TITLE
Add canonical LLM contract normalizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,42 @@ console.log(response.message);
 console.log(`Provider: ${response.provider}, Cost: $${response.usage.cost}`);
 ```
 
+## Canonical Provider Contract
+
+`llm-providers` now exposes an explicit canonical boundary for downstream gateways and coding-agent orchestrators:
+
+```typescript
+import {
+  canonicalToLLMRequest,
+  normalizeLLMRequest,
+  normalizeLLMResponse,
+  type CanonicalLLMRequest,
+} from '@stackbilt/llm-providers';
+```
+
+The intended architecture is:
+
+```text
+client protocol -> gateway adapter -> CanonicalLLMRequest -> llm-providers -> vendor API
+```
+
+Gateways should terminate Anthropic Messages, OpenAI Chat/Responses, Ollama-style local proxy calls, or other client protocols at their own boundary, then normalize into `CanonicalLLMRequest`. Provider selection and vendor translation remain inside this package.
+
+The canonical request is capability-oriented rather than vendor-oriented:
+
+- `messages` and `system` separate normalized chat history from system instructions
+- `sampling` carries `temperature`, `maxTokens`, and `seed`
+- `tools`, `toolMode`, and `builtInTools` describe requested tool behavior
+- `output` describes text, JSON-object, or JSON-schema structured output
+- `media` carries vision inputs independently of provider wire format
+- `workload` and `requirements` describe routing intent and required capabilities
+- `providerOptions` contains namespaced vendor-specific extensions such as Cloudflare `lora` or Cerebras `reasoning`
+- `metadata` carries request identity, tenancy, gateway metadata, cache hints, and custom caller metadata
+
+Existing `LLMRequest` fields are still supported as compatibility input. `normalizeLLMRequest()` maps legacy aliases such as `response_format`, `toolChoice`, `images`, `lora`, `topP`, `frequencyPenalty`, `reasoning`, and `prediction` into the canonical shape. `canonicalToLLMRequest()` converts canonical requests back into the existing adapter input while providers migrate internally.
+
+`normalizeLLMResponse()` provides a stable canonical response shape with normalized routing metadata (`selectedProvider`, `selectedModel`, fallback chain, and capability degradations) while preserving raw provider extras under `metadata`.
+
 ### Auto-Discovery from Environment
 
 ```typescript

--- a/src/__tests__/canonical-contract.test.ts
+++ b/src/__tests__/canonical-contract.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  canonicalToLLMRequest,
+  normalizeLLMRequest,
+  normalizeLLMResponse,
+  type CanonicalLLMRequest,
+} from '../canonical';
+import { OpenAIProvider } from '../providers/openai';
+import { AnthropicProvider } from '../providers/anthropic';
+import { GroqProvider } from '../providers/groq';
+import { CerebrasProvider } from '../providers/cerebras';
+import { NvidiaProvider } from '../providers/nvidia';
+import { CloudflareProvider } from '../providers/cloudflare';
+import { defaultCircuitBreakerManager } from '../utils/circuit-breaker';
+import type { LLMRequest } from '../types';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+const canonicalFixture: CanonicalLLMRequest = {
+  system: 'Return terse answers.',
+  messages: [{ role: 'user', content: 'Return JSON for status ok.' }],
+  sampling: {
+    temperature: 0,
+    maxTokens: 64,
+    seed: 7,
+  },
+  tools: [{
+    type: 'function',
+    function: {
+      name: 'record_status',
+      description: 'Record status.',
+      parameters: {
+        type: 'object',
+        properties: {
+          status: { type: 'string' },
+        },
+        required: ['status'],
+      },
+    },
+  }],
+  toolMode: { toolName: 'record_status' },
+  output: { kind: 'json_object' },
+  workload: 'TOOL_CALLING',
+  requirements: {
+    toolCalling: true,
+    structuredOutput: true,
+  },
+  metadata: {
+    requestId: 'req-canonical',
+    tenantId: 'tenant-a',
+    custom: { trace: 'contract-fixture' },
+  },
+};
+
+function openAICompatibleResponse(model: string, providerContent = '{"ok":true}') {
+  return {
+    ok: true,
+    json: async () => ({
+      id: `chatcmpl-${model}`,
+      object: 'chat.completion',
+      created: 1700000000,
+      model,
+      choices: [{
+        index: 0,
+        message: { role: 'assistant', content: providerContent },
+        finish_reason: 'stop',
+      }],
+      usage: { prompt_tokens: 10, completion_tokens: 4, total_tokens: 14 },
+    }),
+    headers: new Headers({ 'content-type': 'application/json' }),
+  };
+}
+
+describe('canonical provider contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    defaultCircuitBreakerManager.resetAll();
+  });
+
+  it('normalizes legacy response_format into canonical output', () => {
+    const request: LLMRequest = {
+      messages: [{ role: 'user', content: 'JSON please' }],
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'Status',
+          schema: {
+            type: 'object',
+            properties: { ok: { type: 'boolean' } },
+            required: ['ok'],
+          },
+          strict: true,
+        },
+      },
+    };
+
+    const canonical = normalizeLLMRequest(request);
+
+    expect(canonical.output).toEqual({
+      kind: 'json_schema',
+      schemaName: 'Status',
+      schema: request.response_format?.type === 'json_schema'
+        ? request.response_format.json_schema.schema
+        : undefined,
+      strict: true,
+    });
+    expect(Object.keys(canonical)).not.toContain('response_format');
+  });
+
+  it('normalizes legacy toolChoice into canonical toolMode', () => {
+    const canonical = normalizeLLMRequest({
+      messages: [{ role: 'user', content: 'Call the tool' }],
+      tools: canonicalFixture.tools,
+      toolChoice: { type: 'function', function: { name: 'record_status' } },
+    });
+
+    expect(canonical.toolMode).toEqual({ toolName: 'record_status' });
+    expect(Object.keys(canonical)).not.toContain('toolChoice');
+  });
+
+  it('moves legacy provider-specific knobs into providerOptions', () => {
+    const canonical = normalizeLLMRequest({
+      messages: [{ role: 'user', content: 'Hello' }],
+      lora: 'adapter-1',
+      topP: 0.9,
+      frequencyPenalty: 0.2,
+      reasoning: { effort: 'high', format: 'parsed', clearThinking: false },
+      prediction: 'known prefix',
+    });
+
+    expect(canonical.providerOptions).toEqual({
+      cloudflare: {
+        lora: 'adapter-1',
+        topP: 0.9,
+        frequencyPenalty: 0.2,
+      },
+      cerebras: {
+        reasoning: { effort: 'high', format: 'parsed', clearThinking: false },
+        prediction: 'known prefix',
+      },
+    });
+    expect(Object.keys(canonical)).not.toContain('lora');
+    expect(Object.keys(canonical)).not.toContain('prediction');
+  });
+
+  it('normalizes legacy images into canonical media parts', () => {
+    const canonical = normalizeLLMRequest({
+      messages: [{ role: 'user', content: 'Describe this' }],
+      images: [{ data: 'QUJD', mimeType: 'image/png' }],
+    });
+
+    expect(canonical.media).toEqual([{ type: 'image', data: 'QUJD', mimeType: 'image/png' }]);
+    expect(canonical.requirements?.vision).toBe(true);
+    expect(Object.keys(canonical)).not.toContain('images');
+  });
+
+  it('converts canonical requests back to compatibility LLMRequest input', () => {
+    const legacy = canonicalToLLMRequest({
+      ...canonicalFixture,
+      providerOptions: {
+        cloudflare: { lora: 'adapter-1', topP: 0.8, frequencyPenalty: 0.1 },
+        cerebras: { reasoning: { effort: 'medium' }, prediction: 'expected' },
+      },
+    });
+
+    expect(legacy.response_format).toEqual({ type: 'json_object' });
+    expect(legacy.toolChoice).toEqual({ type: 'function', function: { name: 'record_status' } });
+    expect(legacy.lora).toBe('adapter-1');
+    expect(legacy.topP).toBe(0.8);
+    expect(legacy.frequencyPenalty).toBe(0.1);
+    expect(legacy.reasoning).toEqual({ effort: 'medium' });
+    expect(legacy.prediction).toBe('expected');
+    expect(legacy.metadata).toMatchObject({
+      trace: 'contract-fixture',
+      useCase: 'TOOL_CALLING',
+    });
+  });
+
+  it('adds stable canonical response routing metadata', () => {
+    const canonical = normalizeLLMResponse({
+      id: 'res-1',
+      message: 'ok',
+      model: 'llama-3.3-70b-versatile',
+      provider: 'groq',
+      usage: { inputTokens: 10, outputTokens: 2, totalTokens: 12, cost: 0.001 },
+      responseTime: 42,
+      finishReason: 'stop',
+      metadata: { providerRaw: true },
+    }, {
+      routing: {
+        selectedProvider: 'groq',
+        selectedModel: 'llama-3.3-70b-versatile',
+        selectionReason: 'TOOL_CALLING',
+        fallbackChain: [{ provider: 'cerebras', model: 'openai/gpt-oss-120b', reason: 'rate_limit' }],
+        degradations: [{
+          capability: 'structuredOutput',
+          action: 'emulated',
+          reason: 'provider uses prompt-level JSON instruction',
+        }],
+      },
+    });
+
+    expect(canonical.routing).toMatchObject({
+      selectedProvider: 'groq',
+      selectedModel: 'llama-3.3-70b-versatile',
+      selectionReason: 'TOOL_CALLING',
+    });
+    expect(canonical.routing?.fallbackChain).toHaveLength(1);
+    expect(canonical.routing?.degradations?.[0].action).toBe('emulated');
+    expect(canonical.metadata).toEqual({ providerRaw: true });
+  });
+
+  it('prepares one canonical fixture for OpenAI-compatible, Anthropic-compatible, Groq/Cerebras, NVIDIA, and Cloudflare adapters', async () => {
+    const openai = new OpenAIProvider({ apiKey: 'test-key' });
+    mockFetch.mockResolvedValueOnce(openAICompatibleResponse('gpt-4o-mini'));
+    await expect(openai.generateResponse(canonicalToLLMRequest({
+      ...canonicalFixture,
+      model: 'gpt-4o-mini',
+    }))).resolves.toMatchObject({ provider: 'openai', model: 'gpt-4o-mini' });
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body as string).response_format).toEqual({ type: 'json_object' });
+
+    const anthropic = new AnthropicProvider({ apiKey: 'test-key' });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        id: 'msg-test',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: '"ok":true}' }],
+        model: 'claude-3-5-haiku-20241022',
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 10, output_tokens: 3 },
+      }),
+      headers: new Headers({ 'content-type': 'application/json' }),
+    });
+    await expect(anthropic.generateResponse(canonicalToLLMRequest({
+      ...canonicalFixture,
+      model: 'claude-3-5-haiku-20241022',
+    }))).resolves.toMatchObject({ provider: 'anthropic', model: 'claude-3-5-haiku-20241022' });
+    const anthropicBody = JSON.parse(mockFetch.mock.calls[1][1].body as string);
+    expect(anthropicBody.system).toContain('Return terse answers.');
+    expect(anthropicBody.messages.at(-1)).toEqual({ role: 'assistant', content: '{' });
+
+    const groq = new GroqProvider({ apiKey: 'test-key' });
+    mockFetch.mockResolvedValueOnce(openAICompatibleResponse('llama-3.3-70b-versatile'));
+    await expect(groq.generateResponse(canonicalToLLMRequest({
+      ...canonicalFixture,
+      model: 'llama-3.3-70b-versatile',
+    }))).resolves.toMatchObject({ provider: 'groq', model: 'llama-3.3-70b-versatile' });
+
+    const cerebras = new CerebrasProvider({ apiKey: 'test-key' });
+    mockFetch.mockResolvedValueOnce(openAICompatibleResponse('openai/gpt-oss-120b'));
+    await expect(cerebras.generateResponse(canonicalToLLMRequest({
+      ...canonicalFixture,
+      model: 'openai/gpt-oss-120b',
+    }))).resolves.toMatchObject({ provider: 'cerebras', model: 'openai/gpt-oss-120b' });
+
+    const nvidia = new NvidiaProvider({ apiKey: 'test-key' });
+    mockFetch.mockResolvedValueOnce(openAICompatibleResponse('meta/llama-3.3-70b-instruct'));
+    await expect(nvidia.generateResponse(canonicalToLLMRequest({
+      ...canonicalFixture,
+      model: 'meta/llama-3.3-70b-instruct',
+    }))).resolves.toMatchObject({ provider: 'nvidia', model: 'meta/llama-3.3-70b-instruct' });
+
+    const mockAiRun = vi.fn().mockResolvedValueOnce({
+      choices: [{ message: { role: 'assistant', content: '{"ok":true}' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 10, completion_tokens: 4, total_tokens: 14 },
+    });
+    const cloudflare = new CloudflareProvider({ ai: { run: mockAiRun } as unknown as Ai });
+    await expect(cloudflare.generateResponse(canonicalToLLMRequest({
+      ...canonicalFixture,
+      model: '@cf/openai/gpt-oss-120b',
+    }))).resolves.toMatchObject({ provider: 'cloudflare', model: '@cf/openai/gpt-oss-120b' });
+    expect(mockAiRun.mock.calls[0][1].tools).toEqual(canonicalFixture.tools);
+  });
+});

--- a/src/canonical.ts
+++ b/src/canonical.ts
@@ -1,0 +1,459 @@
+import type {
+  BuiltInTool,
+  CacheHints,
+  GatewayMetadata,
+  LLMImageInput,
+  LLMMessage,
+  LLMRequest,
+  LLMResponse,
+  TokenUsage,
+  Tool,
+  ToolCall,
+  ToolResult,
+} from './types.js';
+import type { ModelRecommendationUseCase, ProviderName } from './model-catalog.js';
+
+export interface CanonicalMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  timestamp?: string;
+  toolCalls?: ToolCall[];
+  toolResults?: ToolResult[];
+}
+
+export interface CanonicalMediaPart {
+  type: 'image';
+  data?: string;
+  url?: string;
+  mimeType?: string;
+}
+
+export type CanonicalTool = Tool;
+
+export type CanonicalToolMode =
+  | 'auto'
+  | 'none'
+  | 'required'
+  | { toolName: string };
+
+export interface CanonicalOutputFormat {
+  kind: 'text' | 'json_object' | 'json_schema';
+  schemaName?: string;
+  schema?: Record<string, unknown>;
+  strict?: boolean;
+}
+
+export interface CanonicalSamplingOptions {
+  temperature?: number;
+  maxTokens?: number;
+  seed?: number;
+}
+
+export interface CanonicalRequirements {
+  toolCalling?: boolean;
+  structuredOutput?: boolean;
+  vision?: boolean;
+  longContext?: boolean;
+  builtInTools?: boolean;
+}
+
+export interface CanonicalProviderOptions {
+  cloudflare?: {
+    lora?: string;
+    topP?: number;
+    frequencyPenalty?: number;
+  };
+  cerebras?: {
+    reasoning?: LLMRequest['reasoning'];
+    prediction?: string;
+  };
+  groq?: Record<string, unknown>;
+  nvidia?: Record<string, unknown>;
+  openai?: Record<string, unknown>;
+  anthropic?: Record<string, unknown>;
+}
+
+export interface CanonicalRequestMetadata {
+  requestId?: string;
+  tenantId?: string;
+  gateway?: GatewayMetadata;
+  cache?: CacheHints;
+  custom?: Record<string, unknown>;
+}
+
+export interface CanonicalLLMRequest {
+  messages: CanonicalMessage[];
+  system?: string;
+  model?: string;
+  stream?: boolean;
+  sampling?: CanonicalSamplingOptions;
+  tools?: CanonicalTool[];
+  toolMode?: CanonicalToolMode;
+  builtInTools?: BuiltInTool[];
+  output?: CanonicalOutputFormat;
+  media?: CanonicalMediaPart[];
+  workload?: ModelRecommendationUseCase;
+  requirements?: CanonicalRequirements;
+  providerOptions?: CanonicalProviderOptions;
+  metadata?: CanonicalRequestMetadata;
+}
+
+export interface CanonicalFallbackHop {
+  provider: ProviderName;
+  model?: string;
+  reason?: string;
+}
+
+export interface CanonicalDegradation {
+  capability: string;
+  action: 'stripped' | 'downgraded' | 'emulated' | 'failed';
+  reason: string;
+}
+
+export interface CanonicalRoutingMetadata {
+  selectedProvider: ProviderName;
+  selectedModel: string;
+  selectionReason?: string;
+  fallbackChain?: CanonicalFallbackHop[];
+  degradations?: CanonicalDegradation[];
+}
+
+export interface CanonicalResponseError {
+  class: string;
+  provider?: ProviderName;
+  retryable?: boolean;
+  message: string;
+}
+
+export interface CanonicalLLMResponse {
+  id?: string;
+  message: string;
+  model: string;
+  provider: ProviderName;
+  finishReason?: 'stop' | 'length' | 'tool_calls' | 'content_filter' | 'error';
+  toolCalls?: ToolCall[];
+  usage: TokenUsage;
+  responseTime: number;
+  routing?: CanonicalRoutingMetadata;
+  error?: CanonicalResponseError;
+  metadata?: Record<string, unknown>;
+}
+
+const MODEL_USE_CASES = new Set<string>([
+  'COST_EFFECTIVE',
+  'HIGH_PERFORMANCE',
+  'BALANCED',
+  'TOOL_CALLING',
+  'LONG_CONTEXT',
+  'VISION',
+  'RESEARCH',
+]);
+
+export function normalizeLLMRequest(request: LLMRequest | CanonicalLLMRequest): CanonicalLLMRequest {
+  if (isCanonicalLLMRequest(request)) {
+    return normalizeCanonicalInput(request);
+  }
+
+  const legacyMetadata = copyRecord(request.metadata);
+  const systemMessage = request.messages.find(message => message.role === 'system');
+  const output = normalizeOutputFormat(request.response_format);
+  const media = request.images?.map(imageToMediaPart);
+  const providerOptions = normalizeProviderOptions(request);
+  const workload = normalizeWorkload(legacyMetadata?.useCase);
+  const requirements = normalizeRequirements(request, output, media, workload);
+
+  return {
+    messages: request.messages
+      .filter(message => message.role !== 'system')
+      .map(copyMessage),
+    system: request.systemPrompt ?? systemMessage?.content,
+    model: request.model,
+    stream: request.stream,
+    sampling: {
+      temperature: request.temperature,
+      maxTokens: request.maxTokens,
+      seed: request.seed,
+    },
+    tools: request.tools?.map(copyTool),
+    toolMode: normalizeToolMode(request.toolChoice),
+    builtInTools: request.builtInTools?.map(tool => ({ ...tool })),
+    output,
+    media,
+    workload,
+    requirements,
+    providerOptions,
+    metadata: {
+      requestId: request.requestId,
+      tenantId: request.tenantId,
+      gateway: request.gatewayMetadata,
+      cache: request.cache,
+      custom: legacyMetadata,
+    },
+  };
+}
+
+export function canonicalToLLMRequest(request: CanonicalLLMRequest): LLMRequest {
+  const customMetadata = copyRecord(request.metadata?.custom) ?? {};
+  if (request.workload && customMetadata.useCase === undefined) {
+    customMetadata.useCase = request.workload;
+  }
+
+  const legacy: LLMRequest = {
+    messages: request.messages.map(copyMessage),
+    model: request.model,
+    stream: request.stream,
+    systemPrompt: request.system,
+    temperature: request.sampling?.temperature,
+    maxTokens: request.sampling?.maxTokens,
+    seed: request.sampling?.seed,
+    tools: request.tools?.map(copyTool),
+    builtInTools: request.builtInTools?.map(tool => ({ ...tool })),
+    toolChoice: canonicalToolModeToLegacy(request.toolMode),
+    response_format: canonicalOutputToLegacy(request.output),
+    images: request.media?.map(mediaPartToImage),
+    tenantId: request.metadata?.tenantId,
+    requestId: request.metadata?.requestId,
+    gatewayMetadata: request.metadata?.gateway,
+    cache: request.metadata?.cache,
+    metadata: Object.keys(customMetadata).length > 0 ? customMetadata : undefined,
+  };
+
+  const cloudflare = request.providerOptions?.cloudflare;
+  if (cloudflare) {
+    legacy.lora = cloudflare.lora;
+    legacy.topP = cloudflare.topP;
+    legacy.frequencyPenalty = cloudflare.frequencyPenalty;
+  }
+
+  const cerebras = request.providerOptions?.cerebras;
+  if (cerebras) {
+    legacy.reasoning = cerebras.reasoning;
+    legacy.prediction = cerebras.prediction;
+  }
+
+  return legacy;
+}
+
+export function normalizeLLMResponse(
+  response: LLMResponse,
+  options: {
+    routing?: CanonicalRoutingMetadata;
+    error?: CanonicalResponseError;
+  } = {}
+): CanonicalLLMResponse {
+  return {
+    id: response.id,
+    message: response.message,
+    model: response.model,
+    provider: response.provider as ProviderName,
+    finishReason: response.finishReason,
+    toolCalls: response.toolCalls,
+    usage: response.usage,
+    responseTime: response.responseTime,
+    routing: options.routing ?? {
+      selectedProvider: response.provider as ProviderName,
+      selectedModel: response.model,
+    },
+    error: options.error,
+    metadata: response.metadata,
+  };
+}
+
+function isCanonicalLLMRequest(request: LLMRequest | CanonicalLLMRequest): request is CanonicalLLMRequest {
+  return (
+    'sampling' in request ||
+    'output' in request ||
+    'media' in request ||
+    'providerOptions' in request ||
+    'requirements' in request ||
+    'workload' in request ||
+    'system' in request ||
+    'toolMode' in request
+  );
+}
+
+function normalizeCanonicalInput(request: CanonicalLLMRequest): CanonicalLLMRequest {
+  return {
+    ...request,
+    messages: request.messages.map(copyMessage),
+    sampling: request.sampling ? { ...request.sampling } : undefined,
+    tools: request.tools?.map(copyTool),
+    builtInTools: request.builtInTools?.map(tool => ({ ...tool })),
+    output: request.output ? { ...request.output } : { kind: 'text' },
+    media: request.media?.map(part => ({ ...part })),
+    requirements: request.requirements ? { ...request.requirements } : undefined,
+    providerOptions: copyProviderOptions(request.providerOptions),
+    metadata: request.metadata ? {
+      ...request.metadata,
+      custom: copyRecord(request.metadata.custom),
+    } : undefined,
+  };
+}
+
+function normalizeOutputFormat(format: LLMRequest['response_format'] | undefined): CanonicalOutputFormat {
+  if (!format) {
+    return { kind: 'text' };
+  }
+
+  if (format.type === 'json_schema') {
+    return {
+      kind: 'json_schema',
+      schemaName: format.json_schema.name,
+      schema: format.json_schema.schema,
+      strict: format.json_schema.strict,
+    };
+  }
+
+  return { kind: format.type };
+}
+
+function canonicalOutputToLegacy(output: CanonicalOutputFormat | undefined): LLMRequest['response_format'] {
+  if (!output || output.kind === 'text') {
+    return output?.kind === 'text' ? { type: 'text' } : undefined;
+  }
+
+  if (output.kind === 'json_schema') {
+    return {
+      type: 'json_schema',
+      json_schema: {
+        name: output.schemaName ?? 'response',
+        schema: output.schema ?? {},
+        strict: output.strict,
+      },
+    };
+  }
+
+  return { type: output.kind };
+}
+
+function normalizeToolMode(toolChoice: LLMRequest['toolChoice'] | undefined): CanonicalToolMode | undefined {
+  if (!toolChoice) return undefined;
+  if (toolChoice === 'auto' || toolChoice === 'none') return toolChoice;
+  return { toolName: toolChoice.function.name };
+}
+
+function canonicalToolModeToLegacy(toolMode: CanonicalToolMode | undefined): LLMRequest['toolChoice'] {
+  if (!toolMode) return undefined;
+  if (toolMode === 'auto' || toolMode === 'none') return toolMode;
+  if (toolMode === 'required') return 'auto';
+  return { type: 'function', function: { name: toolMode.toolName } };
+}
+
+function normalizeProviderOptions(request: LLMRequest): CanonicalProviderOptions | undefined {
+  const cloudflare: NonNullable<CanonicalProviderOptions['cloudflare']> = {};
+  if (request.lora !== undefined) cloudflare.lora = request.lora;
+  if (request.topP !== undefined) cloudflare.topP = request.topP;
+  if (request.frequencyPenalty !== undefined) cloudflare.frequencyPenalty = request.frequencyPenalty;
+
+  const cerebras: NonNullable<CanonicalProviderOptions['cerebras']> = {};
+  if (request.reasoning !== undefined) cerebras.reasoning = request.reasoning;
+  if (request.prediction !== undefined) cerebras.prediction = request.prediction;
+
+  const providerOptions: CanonicalProviderOptions = {};
+  if (Object.keys(cloudflare).length > 0) providerOptions.cloudflare = cloudflare;
+  if (Object.keys(cerebras).length > 0) providerOptions.cerebras = cerebras;
+
+  return Object.keys(providerOptions).length > 0 ? providerOptions : undefined;
+}
+
+function normalizeRequirements(
+  request: LLMRequest,
+  output: CanonicalOutputFormat,
+  media: CanonicalMediaPart[] | undefined,
+  workload: ModelRecommendationUseCase | undefined
+): CanonicalRequirements | undefined {
+  const requirements: CanonicalRequirements = {};
+  const hasToolProtocol =
+    (request.tools?.length ?? 0) > 0 ||
+    request.messages.some(message =>
+      (message.toolCalls?.length ?? 0) > 0 || (message.toolResults?.length ?? 0) > 0
+    );
+
+  if (hasToolProtocol) requirements.toolCalling = true;
+  if (output.kind !== 'text') requirements.structuredOutput = true;
+  if ((media?.length ?? 0) > 0) requirements.vision = true;
+  if ((request.builtInTools?.length ?? 0) > 0) requirements.builtInTools = true;
+  if (workload === 'LONG_CONTEXT') requirements.longContext = true;
+
+  return Object.keys(requirements).length > 0 ? requirements : undefined;
+}
+
+function normalizeWorkload(value: unknown): ModelRecommendationUseCase | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.toUpperCase();
+  return MODEL_USE_CASES.has(normalized)
+    ? normalized as ModelRecommendationUseCase
+    : undefined;
+}
+
+function copyMessage(message: LLMMessage | CanonicalMessage): CanonicalMessage {
+  return {
+    role: message.role,
+    content: message.content,
+    timestamp: message.timestamp,
+    toolCalls: message.toolCalls?.map(copyToolCall),
+    toolResults: message.toolResults?.map(copyToolResult),
+  };
+}
+
+function copyTool(tool: Tool): Tool {
+  return {
+    type: tool.type,
+    function: {
+      name: tool.function.name,
+      description: tool.function.description,
+      parameters: {
+        type: tool.function.parameters.type,
+        properties: { ...tool.function.parameters.properties },
+        required: tool.function.parameters.required
+          ? [...tool.function.parameters.required]
+          : undefined,
+      },
+    },
+  };
+}
+
+function copyToolCall(toolCall: ToolCall): ToolCall {
+  return {
+    id: toolCall.id,
+    type: toolCall.type,
+    function: { ...toolCall.function },
+  };
+}
+
+function copyToolResult(toolResult: ToolResult): ToolResult {
+  return { ...toolResult };
+}
+
+function imageToMediaPart(image: LLMImageInput): CanonicalMediaPart {
+  return {
+    type: 'image',
+    data: image.data,
+    url: image.url,
+    mimeType: image.mimeType,
+  };
+}
+
+function mediaPartToImage(part: CanonicalMediaPart): LLMImageInput {
+  return {
+    data: part.data,
+    url: part.url,
+    mimeType: part.mimeType,
+  };
+}
+
+function copyRecord(value: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  return value ? { ...value } : undefined;
+}
+
+function copyProviderOptions(options: CanonicalProviderOptions | undefined): CanonicalProviderOptions | undefined {
+  if (!options) return undefined;
+  return {
+    cloudflare: options.cloudflare ? { ...options.cloudflare } : undefined,
+    cerebras: options.cerebras ? { ...options.cerebras } : undefined,
+    groq: copyRecord(options.groq),
+    nvidia: copyRecord(options.nvidia),
+    openai: copyRecord(options.openai),
+    anthropic: copyRecord(options.anthropic),
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,30 @@ export type {
   BatchJob
 } from './types.js';
 
+// Canonical provider contract
+export {
+  canonicalToLLMRequest,
+  normalizeLLMRequest,
+  normalizeLLMResponse,
+} from './canonical.js';
+export type {
+  CanonicalDegradation,
+  CanonicalFallbackHop,
+  CanonicalLLMRequest,
+  CanonicalLLMResponse,
+  CanonicalMediaPart,
+  CanonicalMessage,
+  CanonicalOutputFormat,
+  CanonicalProviderOptions,
+  CanonicalRequestMetadata,
+  CanonicalRequirements,
+  CanonicalResponseError,
+  CanonicalRoutingMetadata,
+  CanonicalSamplingOptions,
+  CanonicalTool,
+  CanonicalToolMode,
+} from './canonical.js';
+
 // Provider implementations
 export { BaseProvider } from './providers/base.js';
 export { OpenAIProvider } from './providers/openai.js';


### PR DESCRIPTION
## Summary

- Adds `src/canonical.ts` with exported canonical request/response types plus compatibility helpers:
  - `normalizeLLMRequest`
  - `canonicalToLLMRequest`
  - `normalizeLLMResponse`
- Keeps current `LLMRequest` / `LLMResponse` callers working while mapping legacy aliases into a capability-oriented canonical shape.
- Documents the gateway boundary in the README:
  `client protocol -> gateway adapter -> CanonicalLLMRequest -> llm-providers -> vendor API`
- Adds contract tests for legacy alias normalization, provider-specific option namespacing, canonical routing metadata, and adapter preparation across OpenAI-compatible, Anthropic-compatible, Groq/Cerebras, NVIDIA, and Cloudflare paths.

## Validation

- `npm run typecheck`
- `npx vitest run src/__tests__/canonical-contract.test.ts`
- `npm test`

Closes #81.
