### PR TITLE
fix: accept Cerebras tool calls without content

### DIFF
--- a/src/__tests__/tool-call-validation.test.ts
+++ b/src/__tests__/tool-call-validation.test.ts
@@ -361,6 +361,40 @@ describe('Tool call validation at provider boundary', () => {
       provider = new CerebrasProvider({ apiKey: 'test-key' });
     });
 
+    it('should pass Cerebras tool calls when message.content is omitted', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'chatcmpl-1',
+          model: 'zai-glm-4.7',
+          choices: [{
+            index: 0,
+            message: {
+              role: 'assistant',
+              tool_calls: [{
+                id: 'call_ok',
+                type: 'function',
+                function: { name: 'lookup', arguments: '{}' }
+              }]
+            },
+            finish_reason: 'tool_calls'
+          }],
+          usage: baseUsage
+        }),
+        headers: new Headers({ 'content-type': 'application/json' })
+      });
+
+      const res = await provider.generateResponse({
+        messages: [{ role: 'user', content: 'hi' }],
+        model: 'zai-glm-4.7'
+      });
+
+      expect(res.content).toBe('');
+      expect(res.toolCalls).toHaveLength(1);
+      expect(res.toolCalls![0].id).toBe('call_ok');
+      expect(res.toolCalls![0].function.name).toBe('lookup');
+    });
+
     it('should drop Cerebras tool call with empty function.name', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/src/providers/cerebras.ts
+++ b/src/providers/cerebras.ts
@@ -27,7 +27,7 @@ const CEREBRAS_RESPONSE_SCHEMA: SchemaField[] = [
     items: {
       shape: [
         { path: 'message', type: 'object' },
-        { path: 'message.content', type: 'string-or-null' },
+        { path: 'message.content', type: 'string-or-null', optional: true },
         { path: 'finish_reason', type: 'string' },
         {
           path: 'message.tool_calls',
@@ -101,7 +101,7 @@ interface CerebrasResponse {
     index: number;
     message: {
       role: string;
-      content: string | null;
+      content?: string | null;
       tool_calls?: Array<{
         id: string;
         type: 'function';


### PR DESCRIPTION
## Summary
- Allow Cerebras OpenAI-compatible tool-call responses to omit choices[].message.content.
- Keep formatting behavior unchanged: omitted content normalizes to an empty assistant content string.
- Add a regression test for zai-glm-4.7 tool calls where message.content is absent.

## Why
AEGIS gateway model-quality eval reached Cerebras after the llm-gateway developer-role compatibility fix, then failed on schema drift:

Response schema drift at choices[0].message.content: expected string-or-null, got undefined

That shape is recoverable and matches the tolerance already used for Groq/Cloudflare OpenAI-compatible tool-call responses.

## Validation
- npm run typecheck
- npm test (442/442)

## Notes
- Focused provider-contract change only.
- Did not include incidental package-lock version refresh from dependency install.
