### PR TITLE
perf: LatencyHistogram → @stackbilt/wasm-core adapter (closes #96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+### Performance
+- **`LatencyHistogram` backed by WASM (#96)** — `LatencyHistogram` is now a thin adapter over `@stackbilt/wasm-core` (Phase 0). The Rust implementation uses a sorted `Vec` with binary search insertion (O(log N) insert, O(1) percentile read) and a circular eviction index (O(1)) in place of `Array.shift()`. No public API change; existing tests pass unchanged. Requires `--experimental-wasm-modules` in Node.js test environments (added to `vitest.config.ts`).
+
 ## [1.19.0] — 2026-06-23
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@stackbilt/llm-providers",
       "version": "1.19.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@stackbilt/wasm-core": "^0.1.0"
+      },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.0.0",
         "@vitest/coverage-v8": "^1.6.1",
@@ -905,6 +908,12 @@
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@stackbilt/wasm-core": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@stackbilt/wasm-core/-/wasm-core-0.1.0.tgz",
+      "integrity": "sha512-oDr5q+cOnmt7UfaZ7kwFUQkTbEFSFLXDFYzUWS2fFW+Mvl17nW0aIy+inUTsfIH+i2JnyCUkMqrjyRRNEgBFPw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
   "publishConfig": {
     "access": "public",
     "provenance": false
+  },
+  "dependencies": {
+    "@stackbilt/wasm-core": "^0.1.0"
   }
 }

--- a/src/utils/latency-histogram.ts
+++ b/src/utils/latency-histogram.ts
@@ -1,13 +1,4 @@
-/**
- * Latency Histogram
- *
- * Per-provider latency tracking with percentile computation.
- * Uses a sorted insertion ring buffer to keep memory bounded
- * while supporting efficient percentile queries.
- */
-
-/** Maximum samples per provider before oldest are evicted. */
-const DEFAULT_MAX_SAMPLES = 1000;
+import { LatencyHistogram as WasmLatencyHistogram } from '@stackbilt/wasm-core';
 
 export interface LatencySummary {
   p50: number;
@@ -20,83 +11,43 @@ export interface LatencySummary {
 }
 
 export class LatencyHistogram {
-  private buffers: Map<string, number[]> = new Map();
-  private maxSamples: number;
+  private inner: WasmLatencyHistogram;
+  private providers: Set<string> = new Set();
 
-  constructor(maxSamples: number = DEFAULT_MAX_SAMPLES) {
-    this.maxSamples = maxSamples;
+  constructor(maxSamples: number = 1000) {
+    this.inner = new WasmLatencyHistogram(maxSamples);
   }
 
-  /** Record a latency measurement for a provider (in milliseconds). */
   record(provider: string, latencyMs: number): void {
-    let buffer = this.buffers.get(provider);
-    if (!buffer) {
-      buffer = [];
-      this.buffers.set(provider, buffer);
-    }
-
-    buffer.push(latencyMs);
-
-    // Evict oldest when buffer is full.
-    if (buffer.length > this.maxSamples) {
-      buffer.shift();
-    }
+    this.providers.add(provider);
+    this.inner.record(provider, latencyMs);
   }
 
-  /**
-   * Compute a specific percentile for a provider.
-   * @param p Percentile as a number between 0 and 100 (e.g. 95 for p95).
-   * Returns 0 if no data.
-   */
   percentile(provider: string, p: number): number {
-    const buffer = this.buffers.get(provider);
-    if (!buffer || buffer.length === 0) return 0;
-
-    const sorted = [...buffer].sort((a, b) => a - b);
-    const index = Math.ceil((p / 100) * sorted.length) - 1;
-    return sorted[Math.max(0, index)]!;
+    return this.inner.percentile(provider, p);
   }
 
-  /** Get a full summary for a provider. */
   summary(provider: string): LatencySummary {
-    const buffer = this.buffers.get(provider);
-    if (!buffer || buffer.length === 0) {
-      return { p50: 0, p95: 0, p99: 0, min: 0, max: 0, mean: 0, count: 0 };
-    }
-
-    const sorted = [...buffer].sort((a, b) => a - b);
-    const count = sorted.length;
-    const sum = sorted.reduce((a, b) => a + b, 0);
-
-    return {
-      p50: sorted[Math.max(0, Math.ceil(0.50 * count) - 1)]!,
-      p95: sorted[Math.max(0, Math.ceil(0.95 * count) - 1)]!,
-      p99: sorted[Math.max(0, Math.ceil(0.99 * count) - 1)]!,
-      min: sorted[0]!,
-      max: sorted[count - 1]!,
-      mean: sum / count,
-      count,
-    };
+    return this.inner.summary(provider) as LatencySummary;
   }
 
-  /** Get summaries for all tracked providers. */
   allSummaries(): Record<string, LatencySummary> {
     const result: Record<string, LatencySummary> = {};
-    for (const provider of this.buffers.keys()) {
-      result[provider] = this.summary(provider);
+    for (const provider of this.providers) {
+      result[provider] = this.inner.summary(provider) as LatencySummary;
     }
     return result;
   }
 
-  /** Reset one or all providers. */
   reset(provider?: string): void {
-    if (provider) {
-      this.buffers.delete(provider);
+    if (provider !== undefined) {
+      this.providers.delete(provider);
+      this.inner.reset(provider);
     } else {
-      this.buffers.clear();
+      this.providers.clear();
+      this.inner.reset();
     }
   }
 }
 
-/** Shared singleton. */
 export const defaultLatencyHistogram = new LatencyHistogram();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,12 @@ export default defineConfig({
     environment: 'node',
     include: ['src/**/*.test.ts', 'src/**/__tests__/**/*.ts'],
     exclude: ['node_modules', 'dist'],
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        execArgv: ['--experimental-wasm-modules'],
+      },
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'json'],


### PR DESCRIPTION
## Summary

- Replaces the pure-JS `LatencyHistogram` with a thin adapter over `@stackbilt/wasm-core@0.1.0` (Phase 0 of the wasm-core roadmap)
- Rust implementation: sorted `Vec` with binary search insertion — O(log N) insert, O(1) percentile read; O(1) circular eviction replacing `Array.shift()`
- No public API change — same constructor, method signatures, and exact nearest-rank percentile semantics preserved
- `allSummaries()` uses a tracked provider `Set` on the adapter side (works around a `all_summaries()` gap in the WASM binding where the map returns `{}`)

## Test plan

- [x] All 487 existing tests pass (`npm test`) — `observability.test.ts` LatencyHistogram suite covers all semantics including eviction, allSummaries, reset (specific + all), and percentile math
- [x] TypeScript typecheck clean (`npm run typecheck`)
- [x] Vitest config updated with `pool: 'forks'` + `execArgv: ['--experimental-wasm-modules']` to load WASM in the Node.js test environment

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)